### PR TITLE
Handle base64 encoding on macOS

### DIFF
--- a/crcStart.sh
+++ b/crcStart.sh
@@ -32,6 +32,12 @@ if [ -z "$VM_NAME" -o -z "$VM_NAMESPACE" -o -z "$PULL_SECRET_FILE" -o ! -f "$PUL
   exit 1
 fi
 
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  BASE64="base64"
+else
+  BASE64="base64 -w 0"
+fi
+
 oc get namespace ${VM_NAMESPACE} 1>/dev/null
 
 log "> Starting CRC Cluster ${VM_NAME} in namespace ${VM_NAMESPACE} with ${VM_CPUS} CPUs and ${VM_MEMORY} of memory- this can take up to 15 minutes..."
@@ -45,7 +51,7 @@ metadata:
 spec:
   cpu: ${VM_CPUS}
   memory: ${VM_MEMORY}
-  pullSecret: $(cat $PULL_SECRET_FILE | base64 -w 0)
+  pullSecret: $(cat $PULL_SECRET_FILE | $BASE64)
 EOF
 
 log "> Waiting for ${VM_NAME} cluster to be ready"


### PR DESCRIPTION
Issue i am facing on macOS
```
$ ./crcStart.sh test demo pull-secret 
> Starting CRC Cluster test in namespace demo with 4 CPUs and 16Gi of memory- this can take up to 15 minutes...
base64: invalid option -- w
Usage:  base64 [-hvDd] [-b num] [-i in_file] [-o out_file]
  -h, --help     display this message
  -Dd, --decode   decodes input
  -b, --break    break encoded string into num character lines
  -i, --input    input file (default: "-" for stdin)
  -o, --output   output file (default: "-" for stdout)
The CrcCluster "test" is invalid: spec.pullSecret: Invalid value: "null": spec.pullSecret in body must be of type string: "null"
```

Because in macOS ```base64``` implementation doesn't have the ```-w``` flag. The flag is called ```-b``` in macOS and the default value is ```0``` that means ```base64``` in macOS has the same behaviour as base64 ```-w 0``` on Linux.